### PR TITLE
feat: add dnsConfig support to deployment

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "name=changed::true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.6.2
+          version: v3.13.3
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -20,9 +20,9 @@ jobs:
         with:
           version: v3.6.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.13'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -44,5 +44,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config .github/ct.yaml --excluded-charts ""

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,8 +39,10 @@ jobs:
         run: ct lint --config .github/ct.yaml --excluded-charts ""
 
       - name: Create kind cluster
+        id: kind
         uses: helm/kind-action@v1
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config .github/ct.yaml --excluded-charts ""

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --target-branch master)
           if [[ -n "$changed" ]]; then
             echo "name=changed::true" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch master)
           if [[ -n "$changed" ]]; then
-            echo "name=changed::true" >> $GITHUB_OUTPUT
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.6.2
 
@@ -25,7 +25,7 @@ jobs:
           python-version: '3.13'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -39,7 +39,7 @@ jobs:
         run: ct lint --config .github/ct.yaml --excluded-charts ""
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.6.2
+          version: v3.13.3
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,6 @@ jobs:
           version: v3.6.2
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
-        with:
-          charts_repo_url: https://blakeblackshear.github.io/blakeshome-charts
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.6.2
 

--- a/charts/frigate/Chart.yaml
+++ b/charts/frigate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.14.1"
 description: NVR With Realtime Object Detection for IP Cameras
 name: frigate
-version: 7.8.0
+version: 7.8.1
 keywords:
   - tensorflow
   - coral

--- a/charts/frigate/README.md
+++ b/charts/frigate/README.md
@@ -133,3 +133,4 @@ helm upgrade --install \
 | shmSize | string | `"1Gi"` | amount of shared memory to use for caching |
 | strategyType | string | `"Recreate"` | upgrade strategy type (e.g. Recreate or RollingUpdate) |
 | tolerations | list | `[]` | Node toleration configuration |
+| dnsConfig | object | `{}` | Pod's DNS Config |

--- a/charts/frigate/templates/deployment.yaml
+++ b/charts/frigate/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
     {{- end }}
+    {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+    {{- end }}
     {{- if or .Values.extraInitContainers (and .Values.persistence.config.enabled .Values.persistence.config.ephemeralWritableConfigYaml) }}
       initContainers:
       {{- with .Values.extraInitContainers }}

--- a/charts/frigate/values.yaml
+++ b/charts/frigate/values.yaml
@@ -289,3 +289,6 @@ podAnnotations: {}
 
 # -- Define extra init containers
 extraInitContainers: []
+
+# -- Define dnsConfig for containers
+dnsConfig: {}


### PR DESCRIPTION
This PR adds optional support for injecting a custom `dnsConfig` block into the pod spec:

```yaml
{{- if .Values.dnsConfig }}
  dnsConfig:
    {{- toYaml .Values.dnsConfig | nindent 8 }}
{{- end }}
```

### 📌 Motivation

By default, Kubernetes kubelets (I don't really know if it's only on my k3s) sets the [`ndots` option](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) to `ndots:5`, which causes the DNS resolver to **attempt resolution using internal cluster search domains first**. This can lead to unexpected and sometimes problematic behavior, especially for pods resolving **external fully-qualified domain names** (FQDNs) that are **missing the trailing dot**.

#### Example:

* Frigate in the pod tries to resolve `stun.l.google.com`
* Instead of directly resolving it via public DNS, Kubernetes attempts:

  * `stun.l.google.com.<localdomain>.svc.cluster.local`
  * `stun.l.google.com.<namespace>.svc.cluster.local`
  * `stun.l.google.com.myhouselocaldomain.local`
* This leads to **slow responses or timeouts**, or even incorrect DNS resolution if internal zones match the pattern

This behavior is well explained in this old post:

* [[DNS resolution & ndots in Kubernetes - G. Pracucci](https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html)](https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html)

### 🛠️ Use Case

In my case, I observed issues where DNS queries for `stun.l.google.com` were being resolved as:

```
stun.l.google.com.mydomain.local
```

...because the application does not append a trailing dot (`.`) to force absolute resolution, and the default `ndots` behavior kicks in. This causes:

* Unnecessary DNS traffic to internal resolvers (e.g., CoreDNS inside of my kube cluster, and my external coreDNS lab dnsServer)
* Resolution failures if internal resolvers cannot handle such queries (I tracked all error I can see) 
* Could lead to slower startup or degraded application behavior in general case (Not necessarily here)

### ✅ Solution

By allowing `.Values.dnsConfig` to be passed and templated into the pod spec, we can configure options like:

```yaml
dnsConfig:
  options:
    - name: ndots
      value: "1" # or 2
```

This enforces faster and more predictable DNS resolution—especially for external FQDNs—and unlocks other dnsConfig tweaks for DNS maniacs like myself.